### PR TITLE
Updating .newdev & removing .consolidate

### DIFF
--- a/cogs/ecosystem.py
+++ b/cogs/ecosystem.py
@@ -143,13 +143,14 @@ The Ergo blockchain launched in 2019 with no pre-mining or pre-allocation of any
 
 def faq_newdev():
 	df = """If you are a developer new to the Ergo ecosystem, these links may be useful:
-- Documentation: <https://docs.ergoplatform.com/dev/start/>
-- Developer Channel: <https://discord.gg/ergo-platform-668903786361651200>
-- DeCo Education: <https://www.youtube.com/@decoeducation9394>
-- Ergohack: <https://ergohack.io/>
-- Ergo Appkit: <https://github.com/ergoplatform/ergo-appkit>
-- Fleet: <https://fleet-sdk.github.io/docs/>
-	"""
+	
+	- Documentation: <https://docs.ergoplatform.com/dev/start/>
+	- Ergo Appkit: <https://github.com/ergoplatform/ergo-appkit>
+	- Fleet: <https://fleet-sdk.github.io/docs/>
+	- DeCo Education: <https://www.youtube.com/@decoeducation9394>
+	- Ergohack: <https://ergohack.io/>
+
+To access the Development channel in Discord, go to channels in the side bar. Click Channels & Roles (near the top). Then, select Start Developing."""
 	return(df)
 
 class Ecosystem(commands.Cog):

--- a/cogs/wallets.py
+++ b/cogs/wallets.py
@@ -99,12 +99,6 @@ Pro-Tip: If you restore the same wallet into each service, you can use the same 
 Modifiers: `dis`, `reddit`, `tg`, `twitter`"""
 	return(df)
 
-def faq_consolidate():
-	df = """
-If you are having trouble with a transaction, often you can correct it by consolidating your transaction by sending assets to yourself. Whether it is many small mining payments, staking/unstaking Ergopad, limits on the dat size of transactions on chain.  if you send the tokens, NFTs, staking keys and Erg to yourself in one transaction. This will consolidate the tokens & your erg into one utxo. Then retry your transaction. This solves many problems users of the Ergo blockchain experience. If it still does not work after consolidation, please try one of our support channels. Thank you.
-	"""
-	return(df)
-
 class Wallets(commands.Cog):
 	def __init__(self, client):
 		self.client = client 
@@ -132,11 +126,6 @@ class Wallets(commands.Cog):
 		modifier = modifier.lower()
 		response = faq_tipbot(modifier)
 		await ctx.send(response)
-
-	@commands.command()
-	async def consolidate(self, ctx):
-		await ctx.send(faq_consolidate())
-
 
 async def setup(client):
 	await client.add_cog(Wallets(client))


### PR DESCRIPTION
See what you did with adding brackets around urls. I'll do that in the future. Added directions to the dev channels in .newdev. .consolidate is doing doubles in Ergopad, so removing. Does raise the question of integrating into sigmabot and using some prefix and qualifier for projects, such as .spf consolidate and .pad consolidate, and separate them into different cogs. Not sure if this is something that you, the projects or anyone else wants. So, leaving alone for now.